### PR TITLE
点击每一页会发生跳转两页bug

### DIFF
--- a/vue-slide.vue
+++ b/vue-slide.vue
@@ -51,7 +51,9 @@ export default {
                     /* Hack - would normally use e.timeStamp but it's whack in Fx/Android */
                     this.slide.init.start.t = new Date().getTime();
                     this.slide.init.start.x = e.targetTouches[0].clientX;
+                    this.slide.init.end.x = e.targetTouches[0].clientX;
                     this.slide.init.start.y = e.targetTouches[0].clientY;
+                    this.slide.init.end.y = e.targetTouches[0].clientY;
                 }
 
             } else {
@@ -192,9 +194,6 @@ export default {
     @touchmove="swipeMove"
     @touchstart="swipeStart"
     @touchend="swipeEnd"
-    @mousedown="swipeStart"
-    @mouseup="swipeEnd"
-    @mousemove="swipeMove"
     >
         <slot></slot>
     </div>


### PR DESCRIPTION
看了下代码，发现每次点击（不移动）每一页的时候，会触发两次swipeStart，两次swipeEnd， 中间没有swipeMove。 而你this.slide.init.end.x的值是在swipeMove的时候赋值上去的。
针对我移动端的使用场景，我把mouseXXX的事件去掉了===》修复了触发两次
在swipeStart时候，同时赋值this.slide.init.end.x，this.slide.init.end.y===》 是的调用swipeEnd时候，this.slide.init.end.x的值不是上次move后最终的值。
