### PR TITLE
Fix resize listeners

### DIFF
--- a/vue-slide.vue
+++ b/vue-slide.vue
@@ -129,8 +129,8 @@ export default {
         }
     },
     mounted () {
-        _.on(window, 'resize', this.init())
-        _.on(this.$el, 'resize', this.init())
+        _.on(window, 'resize', this.init)
+        _.on(this.$el, 'resize', this.init)
     },
     beforeDestroy () {
         if (this.$touch) {

--- a/vue-slide.vue
+++ b/vue-slide.vue
@@ -131,6 +131,7 @@ export default {
     mounted () {
         _.on(window, 'resize', this.init)
         _.on(this.$el, 'resize', this.init)
+        this.init()
     },
     beforeDestroy () {
         if (this.$touch) {


### PR DESCRIPTION
init() wasn't called when resizing the window because you were passing a method call instead of a method :-)

Also, it might be a good idea to store an object with all events listeners and clear them on `beforeDestroy (thinking of window events).